### PR TITLE
Bump `base` version bounds

### DIFF
--- a/these-skinny.cabal
+++ b/these-skinny.cabal
@@ -33,7 +33,7 @@ Library
   Exposed-modules:     Data.These
 
   Build-depends:
-      base                     >= 4.4     && < 4.13
+      base                     >= 4.4     && < 4.18
     , deepseq                  >= 1.3.0.0 && < 1.5
     , ghc-prim
 


### PR DESCRIPTION
Tested to work with `allow-newer` on `refined`